### PR TITLE
Työryhmät näkyviin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,3 +27,6 @@ social:
 markdown: kramdown
 permalink: pretty
 
+collections:
+  - tyoryhmat
+

--- a/_tyoryhmat/bazaar.md
+++ b/_tyoryhmat/bazaar.md
@@ -1,0 +1,9 @@
+---
+title: Bazaar
+active: no
+begin: Q1/2014
+end: Q4/2014
+---
+
+[Sampo Software](http://samposoftware.com/) työsti ensimmäisen version Bazaar-palvelusta.
+

--- a/_tyoryhmat/demola_2014_interfalizer.md
+++ b/_tyoryhmat/demola_2014_interfalizer.md
@@ -1,0 +1,11 @@
+---
+title: "Demola: Interfacelizer"
+more_info:
+  url: http://tampere.demola.net/projects/educloud-bazaar-user-interfacelizer
+  title: Project info
+active: no
+---
+
+Tampereen Demolassa oli vuonna 2015 tiimi tehtävänannolla:
+
+    The aim is to design and implement user interfaces for upper secondary education and higher education in EduCloud Bazaar.

--- a/_tyoryhmat/mpass.md
+++ b/_tyoryhmat/mpass.md
@@ -1,0 +1,17 @@
+---
+title: MPASS
+begin: Q1/2015
+more_info:
+  url: http://www.mpass.fi/roadmap/
+  title: Roadmap
+active: yes
+---
+
+PASS-tunnistamisratkaisu toteuttaa ECA Auth-tunnistamisrajapinnan, joka on osaratkaisu
+digitaalisten oppimisympäristöjen laajempaan käyttöön.
+
+Kehitys on tehty avoimen lähdekoodin
+periaatteella opetus- ja kulttuuriministeriön (OKM) ohjauksessa TUIMA-projektissa
+valtiovarainministeriön rahoituksella.
+Pääasiallinen toteuttaja on ollut CSC – Tieteen tietotekniikan keskus.
+

--- a/_tyoryhmat/roledb.md
+++ b/_tyoryhmat/roledb.md
@@ -1,0 +1,10 @@
+---
+title: RoleDB
+active: no
+begin: Q1/2014
+end: Q4/2014
+---
+
+[Haltu](http://haltu.fi) työsti roolitietokantana tunnetun palvelun.
+
+

--- a/tyoryhmat.html
+++ b/tyoryhmat.html
@@ -3,7 +3,7 @@ layout: page
 title: Työryhmät
 ---
 
-<section id="foo" class="container content-section">
+<section class="container content-section">
 <div class="row">
 <div class="col-lg-8">
 
@@ -80,5 +80,54 @@ Tiistaisin klo 13-14.
 </div>
 
 </div>
+</section>
+
+
+<section class="container content-section">
+<div class="row">
+<div class="col-lg-12">
+<h1>Käynnissä olevat työryhmät</h1>
+</div>
+</div>
+
+{% for p in site.tyoryhmat %}{% if p.active != false %}
+<div class="row">
+<div class="col-lg-4">
+<h2>{{ p.title }}</h2>
+<p>{{ p.begin }} - {{ p.end }}</p>
+{% if p.more_info %}<p><a href="{{ p.more_info.url }}">{{ p.more_info.title }}</a></p>{% endif %}
+</div>
+
+<div class="col-lg-8">
+{{ p.output }}
+</div>
+
+</div>
+<hr />
+{% endif %}{% endfor %}
+</section>
+
+<section class="container content-section">
+<div class="row">
+<div class="col-lg-12">
+<h1>Työnsä lopettaneet työryhmät</h1>
+</div>
+</div>
+
+{% for p in site.tyoryhmat %}{% if p.active == false %}
+<div class="row">
+<div class="col-lg-4">
+<h2>{{ p.title }}</h2>
+<p>{{ p.begin }} - {{ p.end }}</p>
+{% if p.more_info %}<p><a href="{{ p.more_info.url }}">{{ p.more_info.title }}</a></p>{% endif %}
+</div>
+
+<div class="col-lg-8">
+{{ p.output }}
+</div>
+
+</div>
+<hr />
+{% endif %}{% endfor %}
 </section>
 


### PR DESCRIPTION
Työryhmät-sivulla on listattuna käynnissä olevat ja työnsä lopettaneet työryhmät. Tiedot työryhmistä on omassa "_tyoryhmat" hakemistossa jonne niitä on helppo lisätä.

@kyyberi Jotain tälläistäkö ajattelit #5 ?

@preriasusi Onko sinulla vielä tallessa lista kaikista vuonna 2014 ja 2015 käynnissä olleista työryhmistä?
